### PR TITLE
Add Fig as an installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ Another :star:theme for oh-my-zsh
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/skylerlee/zeta-zsh-theme/master/scripts/install.sh)"
 ```
 
+### Fig
+
+
+Install `zeta-zsh-theme` with [Fig](https://fig.io) in just one click.
+
+<a href="https://fig.io/plugins/other/zeta-zsh-theme_skylerlee" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 ### Manually
 
 1. Copy file `zeta.zsh-theme` to `$ZSH_CUSTOM/themes` folder.


### PR DESCRIPTION
We recently listed `zeta-zsh-theme` on [Fig Plugin Store](https://fig.io/plugins), so we'd love to have Fig displayed as a download method on your readme. Thanks so much and please let me know if you have any questions!